### PR TITLE
[CB-2235] Encoded spaces to fix a test.

### DIFF
--- a/autotest/tests/filetransfer.tests.js
+++ b/autotest/tests/filetransfer.tests.js
@@ -138,7 +138,7 @@ describe('FileTransfer', function() {
         });
         it("should be able to download a file using file:// (when hosted from file://)", function() {
             var fail = createDoNotCallSpy('downloadFail');
-            var remoteFile = window.location.href.replace(/\?.*/, '');
+            var remoteFile = window.location.href.replace(/\?.*/, '').replace(/ /g, '%20');
             var localFileName = remoteFile.substring(remoteFile.lastIndexOf('/')+1);
             var lastProgressEvent = null;
 


### PR DESCRIPTION
FileTransfer.download fails when the source URL has spaces.  One test was failing because an attempt was accidentally being made to download from a URL with spaces; once encoded, the test passes.
