### PR TITLE
[CB-1933] Added a test for confirmation dialogs.

### DIFF
--- a/autotest/tests/notification.tests.js
+++ b/autotest/tests/notification.tests.js
@@ -21,7 +21,7 @@
 
 describe('Notification (navigator.notification)', function () {
 	it("should exist", function() {
-        expect(navigator.notification).toBeDefined();
+                expect(navigator.notification).toBeDefined();
 	});
 
 	it("should contain a vibrate function", function() {
@@ -34,8 +34,13 @@ describe('Notification (navigator.notification)', function () {
 		expect(typeof navigator.notification.beep).toBe("function");
 	});
 
-	it("should contain a alert function", function() {
+	it("should contain an alert function", function() {
 		expect(typeof navigator.notification.alert).toBeDefined();
 		expect(typeof navigator.notification.alert).toBe("function");
+	});
+
+	it("should contain a confirm function", function() {
+		expect(typeof navigator.notification.confirm).toBeDefined();
+		expect(typeof navigator.notification.confirm).toBe("function");
 	});
 });

--- a/notification/index.html
+++ b/notification/index.html
@@ -56,7 +56,7 @@
         console.log("After alert");
     };
 
-    var confirmDialog = function(message, title, buttons) {
+    var confirmDialogA = function(message, title, buttons) {
         navigator.notification.confirm(message,
             function(r) {
                 console.log("You selected " + r);
@@ -65,7 +65,17 @@
             title,
             buttons);
     };
-    
+
+    var confirmDialogB = function(message, title, buttons) {
+        navigator.notification.confirm(message,
+            function(r) {
+                console.log("You selected " + r);
+                alert("You selected " + buttons[r-1]);
+            },
+            title,
+            buttons);
+    };
+
     /**
      * Function called when page has finished loading.
      */
@@ -94,7 +104,8 @@
     <div class="btn large" onclick="beep();">Beep</div>
     <div class="btn large" onclick="vibrate();">Vibrate</div>
     <div class="btn large" onclick="alertDialog('You pressed alert.', 'Alert Dialog', 'Continue');">Alert Dialog</div>
-    <div class="btn large" onclick="confirmDialog('You pressed confirm.', 'Confirm Dialog', 'Yes,No,Maybe');">Confirm Dialog</div>
+    <div class="btn large" onclick="confirmDialogA('You pressed confirm.', 'Confirm Dialog', 'Yes,No,Maybe');">Confirm Dialog A</div>
+    <div class="btn large" onclick="confirmDialogB('You pressed confirm.', 'Confirm Dialog', ['Yes', 'No', 'Maybe, Not Sure']);">Confirm Dialog B</div>
     <div class="btn large" onclick="alert('You pressed alert.');">Built-in Alert Dialog</div>
     <div class="btn large" onclick="confirm('You selected confirm');">Built-in Confirm Dialog</div>
     <div class="btn large" onclick="prompt('This is a prompt.', 'Default value');">Built-in Prompt Dialog</div>


### PR DESCRIPTION
Notification.confirm now takes an array of button labels.  Comma-separated strings are deprecated.
