### PR TITLE
CB-4130: fixed test to check for the text body of the response only

### DIFF
--- a/autotest/tests/filetransfer.tests.js
+++ b/autotest/tests/filetransfer.tests.js
@@ -323,7 +323,7 @@ describe('FileTransfer', function() {
             var localFileName = remoteFile.substring(remoteFile.lastIndexOf('/')+1);
             var downloadFail = jasmine.createSpy().andCallFake(function(error) {
                 expect(error.body).toBeDefined();
-                expect(error.body).toEqual('You requested a 404\n');
+                expect(error.body).toMatch('You requested a 404');
             });
 
             this.after(function() {


### PR DESCRIPTION
mobilespec filetransfer.spec.13 was failing on android because of a difference in the trailing newline.
