### PR TITLE
[CB-4568] Disable pop-up messages when running test "XHR to within-packa...

### DIFF
--- a/benchmarks/autobench.html
+++ b/benchmarks/autobench.html
@@ -127,7 +127,8 @@ function bench() {
         xhr.open("GET", "../LICENSE", true);
         xhr.onreadystatechange = function() {
             if (xhr.readyState == 4) {
-                if (xhr.status == 200) {
+                 //The result status is being compared to 0 for success instead of 200. This is because the file and ftp schemes do not use HTTP result codes.
+                if (xhr.status == 0 && xhr.responseText.length > 0) {
                     next();
                 } else {
                     alert('There was a problem during XHR file read!');
@@ -188,5 +189,6 @@ function bench() {
         <tbody id="table-results">
         </tbody>
     </table>
+    <h2>&nbsp</h2><a href="javascript:" class="backBtn" onclick="backHome();">Back</a><br>
   </body>
 </html>      


### PR DESCRIPTION
...ge 11kb asset."

When fetching a file from the local file system, the result status of XMLHttpRequest should be compared to 0 for success instead of 200.  This is because the file and ftp schemes do not use HTTP result codes.

FYI:https://developer.mozilla.org/es/docs/XMLHttpRequest/Usar_XMLHttpRequest
