### PR TITLE
[CB-4568] Disable pop-up messages when running test "XHR to within-package 11kb asset."

### DIFF
--- a/benchmarks/autobench.html
+++ b/benchmarks/autobench.html
@@ -27,7 +27,6 @@
     <link rel="stylesheet" href="../master.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <script type="text/javascript" charset="utf-8" src="../cordova-incl.js"></script>      
     <script type="text/javascript" charset="utf-8" src="uubench.js"></script>
-    <script type="text/javascript" charset="utf-8" src="licensecontents.js"></script>
 <script>
     var exec = cordova.require('cordova/exec');
     var temp, pers, LICENSE_CONTENTS;
@@ -62,6 +61,7 @@
         min: 2000, // each benchmark should run for at least 2000ms
         done:function() { 
             $('loading').innerHTML = "Benchmarks complete.";
+            $('backBtn').style.display="block";
         }
     });
     var results = {};
@@ -176,7 +176,7 @@ function bench() {
 </script>
 
   </head>
-  <body>
+  <body id="stage" class="theme">
     <h1>Auto-Benchmarks</h1>
     <h2 id="loading"></h2>
     <table>
@@ -189,5 +189,6 @@ function bench() {
         <tbody id="table-results">
         </tbody>
     </table>
+    <h2>&nbsp</h2><a href="javascript:" class="backBtn" style="display:none" id='backBtn' onclick="backHome();">Back</a><br>
   </body>
 </html>      


### PR DESCRIPTION
When fetching a file from the local file system, the result status of
XMLHttpRequest should be compared to 0 for success instead of 200.
This is because the file and ftp schemes do not use HTTP result codes.

FYI:https://developer.mozilla.org/es/docs/XMLHttpRequest/Usar_XMLHttpReq
uest
