### PR TITLE
CB-5840: Update Location test to fix the info field is alway displaying ...

### DIFF
--- a/location/index.html
+++ b/location/index.html
@@ -109,9 +109,10 @@
             setLocationStatus("Error: "+e.code);
         };
 
+        setLocationStatus("Retrieving location...");
+
         // Get location
         geo.getCurrentPosition(success, fail, opts || {enableHighAccuracy: true}); //, {timeout: 10000});
-        setLocationStatus("Retrieving location...");
 
     };
 


### PR DESCRIPTION
..."Retrieving location..."

If we click "Get Location Up to 30 Seconds Old" twice within 30 secs,
since the second time the success callback will be invoke immediately,
the location status will be set as “Done” first and then be set as
“Retrieving location…”, that’s why it’s always displaying  "Retrieving
location..."
