### PR TITLE
CB-6549 use relative path to link assets

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -111,7 +111,7 @@ try {
 // Setting up config.fatal as true, if something goes wrong the program it will terminate
 shelljs.config.fatal = true;
 // Creating the project, linked to cordova-mobile-spec library
-shelljs.exec(cordova_cli + " create mobilespec org.apache.cordova.mobilespec MobileSpec_Tests --link-to " + cordova_ms);
+shelljs.exec(cordova_cli + " create mobilespec org.apache.cordova.mobilespec MobileSpec_Tests --link-to cordova-mobile-spec");
 
 // Executing grunt task, to generate updated js files for each platform
 shelljs.pushd(cordova_js);


### PR DESCRIPTION
Changed: Use relative path instead of absolute path, to link the
cordova-mobile-spec repository with the mobilespec project.
