### PR TITLE
CB-6669 Fix blackberry10 path

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -159,7 +159,7 @@ if (argv.plugman) {
         "name" :  "mobilespec",
         "lib" :   { "android" :      { "uri" : top_dir + "cordova-android" },
                     "ios" :          { "uri" : top_dir + "cordova-ios" },
-                    "blackberry10" : { "uri" : top_dir + "cordova-blackberry" },
+                    "blackberry10" : { "uri" : top_dir + "cordova-blackberry" + path.sep + "blackberry10" },
                     "wp8" :          { "uri" : top_dir + "cordova-wp8" },
                     "windows8" :     { "uri" : top_dir + "cordova-windows" }
         }


### PR DESCRIPTION
The blackberry10 code doesn't reside in the root of the blackberry respository, as is the case with the other platform repositories.

This commit adds the required blackberry10 subdirectory to the config.json written by createmobilespec.js

Output after calling

```
cordova-mobile-spec\createmobilespec\createmobilespec.js --blackberry10
```

``````
Creating project. If you have any errors, it may be from missing repositories.
To clone needed repositories (android as an example):
  ./cordova-coho/coho repo-clone -r plugins -r mobile-spec -r android -r cli
To update all repositories:
  ./cordova-coho/coho repo-update
Creating project mobilespec...
Creating a new cordova project with name "MobileSpec_Tests" and id "org.apache.cordova.mobilespec" at location "C:\GitHub\mobilespec"
Using custom www assets from C:\GitHub\cordova-mobile-spec
C:\GitHub\mobilespec C:\GitHub
Adding platforms...
Adding Platform: blackberry10
Checking if platform "blackberry10" passes minimum requirements...
Requirements check failed: blackberry-nativepackager cannot be found on the path. Aborting.```
``````

I don't have the blackberry10 toolset installed, so check_req fails, but check_req is now at least invoked. :)
