### PR TITLE
[CB-6822] plugman compatible on Windows platforms

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -217,10 +217,11 @@ if (argv.plugman) {
 if (argv.plugman) {
     console.log("Adding plugins using plugman...");
     platforms.forEach(function (platform) {
-        var projName = getProjName(platform);
+        var projName = getProjName(platform),
+            nodeCommand = /^win/.test(process.platform) ? process.argv[0] +" " : "";
         shelljs.pushd(projName);
         // plugin path must be relative and not absolute (sigh)
-        shelljs.exec(path.join(top_dir, "cordova-plugman", "main.js") + 
+        shelljs.exec(nodeCommand + path.join(top_dir, "cordova-plugman", "main.js") + 
                      " install --platform " + platform +
                      " --project . --plugin " + path.join("..", "cordova-mobile-spec", "dependencies-plugin") +
                      " --searchpath " + top_dir);


### PR DESCRIPTION
When createmobilespec module is used and the --plugman argument is
present, it will determine if the development platform is windows to add
node as part of the command.

process.argv[0] it will retrieve the node from the current process, and
it will cover the scenario where the nodejs installation it has a custom
path or it's not present in system PATH environmental variable.

If:
/path/to/nodejs/node createmobilespec.js [args]
process.argv[0] it will retrieve: /path/to/nodejs/node
to invoke plugman main.js file.
