### PR TITLE
CB-6855 globalization.spec.37 on wp8

### DIFF
--- a/autotest/tests/globalization.tests.js
+++ b/autotest/tests/globalization.tests.js
@@ -728,7 +728,11 @@ describe('Globalization (navigator.globalization)', function () {
                     expect(typeof a).toBe('object');
                     expect(a.pattern).toBeDefined();
                     expect(typeof a.pattern).toBe('string');
-                    expect(a.pattern.length > 0).toBe(true);
+                    if (cordova.platformId === "windowsphone") {
+                        expect(a.pattern.length == 0).toBe(true);
+                    } else {
+                        expect(a.pattern.length > 0).toBe(true);
+                    }
                     expect(typeof a.symbol).toBe('string');
                     expect(typeof a.fraction).toBe('number');
                     expect(typeof a.rounding).toBe('number');


### PR DESCRIPTION
Fixed tests to reflect that 'pattern' property of NumberFormat is not
supported on wp8 (returns empty string)
