### PR TITLE
CB-6856 globalization.spec.38 on wp8

### DIFF
--- a/autotest/tests/globalization.tests.js
+++ b/autotest/tests/globalization.tests.js
@@ -763,7 +763,11 @@ describe('Globalization (navigator.globalization)', function () {
                     expect(typeof a).toBe('object');
                     expect(a.pattern).toBeDefined();
                     expect(typeof a.pattern).toBe('string');
-                    expect(a.pattern.length > 0).toBe(true);
+                    if (cordova.platformId === "windowsphone") {
+                        expect(a.pattern.length == 0).toBe(true);
+                    } else {
+                        expect(a.pattern.length > 0).toBe(true);
+                    }
                     expect(typeof a.symbol).toBe('string');
                     expect(typeof a.fraction).toBe('number');
                     expect(typeof a.rounding).toBe('number');


### PR DESCRIPTION
Fixed test to reflect that wp8 does not support the 'pattern' property of
getNumberPattern, returns empty string
