### PR TITLE
CB-6857 globalization.spec.39 on wp8

### DIFF
--- a/autotest/tests/globalization.tests.js
+++ b/autotest/tests/globalization.tests.js
@@ -798,7 +798,11 @@ describe('Globalization (navigator.globalization)', function () {
                     expect(typeof a).toBe('object');
                     expect(a.pattern).toBeDefined();
                     expect(typeof a.pattern).toBe('string');
-                    expect(a.pattern.length > 0).toBe(true);
+                    if (cordova.platformId === "windowsphone") {
+                        expect(a.pattern.length == 0).toBe(true);
+                    } else {
+                        expect(a.pattern.length > 0).toBe(true);
+                    }
                     expect(typeof a.symbol).toBe('string');
                     expect(typeof a.fraction).toBe('number');
                     expect(typeof a.rounding).toBe('number');


### PR DESCRIPTION
Fixed test to reflect unsupported property 'pattern' of NumberFormat for
windows (empty string should be returned)
