### PR TITLE
CB-7010 (WP8) compare proper string for path

### DIFF
--- a/autotest/tests/file.tests.js
+++ b/autotest/tests/file.tests.js
@@ -1515,6 +1515,7 @@ describe('File API', function() {
                 dirName2 = "num 2",
                 rootPath = root.fullPath,
                 fail = createFail('Entry');
+                expectedPath = cordova.platformId === 'windowsphone' ? '//num 1/num 2' : '/num%201/num%202/';
 
             createDirectory(dirName1, createNext, fail);
             function createNext(e1) {
@@ -1523,7 +1524,7 @@ describe('File API', function() {
             var check = jasmine.createSpy().andCallFake(function(entry) {
                 var uri = entry.toURL();
                 expect(uri).toBeDefined();
-                expect(uri).toContain('/num%201/num%202/');
+                expect(uri).toContain(expectedPath);
                 expect(uri.indexOf(rootPath)).not.toBe(-1);
                 // cleanup
                 deleteEntry(dirName1);


### PR DESCRIPTION
In case of platformId === 'windowsphone', compare with proper string('//num 1/num 2'),
the test fails because WP8 platform it doesn't recognize
/num%201/num%202/.
