### PR TITLE
CB-7011 (WP8) proper file name if windowsphone

### DIFF
--- a/autotest/tests/file.tests.js
+++ b/autotest/tests/file.tests.js
@@ -2978,7 +2978,7 @@ describe('File API', function() {
 
     describe('read method', function(){
         it("file.spec.82 should error out on non-existent file", function() {
-            var fileName = "somefile.txt";
+            var fileName = cordova.platformId === 'windowsphone' ? root.toURL() + "/" + "somefile.txt" : "somefile.txt";
             var getFileFail = createFail('create');
             var fileFail = createFail('file');
             var deleteFail = createFail('delete');


### PR DESCRIPTION
in case of platformId === 'windowsphone' it will use a proper path to determine if the file exists or not, instead of just thow a ENCODING_ERR error code.
