### PR TITLE
CB-7012, WP8 it doesn't support write binary

### DIFF
--- a/autotest/tests/file.tests.js
+++ b/autotest/tests/file.tests.js
@@ -3763,7 +3763,7 @@ describe('File API', function() {
             // Skip test if Blobs are not supported (e.g.: Android 2.3).
             if ( (typeof window.Blob != 'function' &&
                   typeof window.WebKitBlobBuilder == 'undefined') ||
-                typeof window.ArrayBuffer == 'undefined') {
+                  cordova.platformId === 'windowsphone') {
                 return;
             }
             var dummyFileName = "blobwriter.bin",


### PR DESCRIPTION
If the platform is windowsphone it will skip the test, windows phone it doesn't support write binary data from a file at the moment.
