### PR TITLE
CB-7013 (WP8) use proper string to compare

### DIFF
--- a/autotest/tests/file.tests.js
+++ b/autotest/tests/file.tests.js
@@ -4028,6 +4028,7 @@ describe('File API', function() {
         /* These specs verify that FileEntries have a toNativeURL method
          * which appears to be sane.
          */
+        var pathExpect = cordova.platformId === 'windowsphone' ? "//nativ" : "file://";
         it("file.spec.114 fileEntry should have a toNativeURL method", function() {
             var fileName = "native.file.uri",
                 win = jasmine.createSpy().andCallFake(function(fileEntry) {
@@ -4043,7 +4044,7 @@ describe('File API', function() {
                     expect(typeof entry.toNativeURL).toBe('function');
                     var nativeURL = entry.toNativeURL();
                     expect(typeof nativeURL).toBe("string");
-                    expect(nativeURL.substring(0,7)).toEqual("file://");
+                    expect(nativeURL.substring(0,7)).toEqual(pathExpect);
                     expect(nativeURL.substring(nativeURL.length - fileName.length)).toEqual(fileName);
                 });
 
@@ -4066,7 +4067,7 @@ describe('File API', function() {
                     expect(typeof entries[0].toNativeURL).toBe('function');
                     var nativeURL = entries[0].toNativeURL();
                     expect(typeof nativeURL).toBe("string");
-                    expect(nativeURL.substring(0,7)).toEqual("file://");
+                    expect(nativeURL.substring(0,7)).toEqual(pathExpect);
                     expect(nativeURL.substring(nativeURL.length - fileName.length)).toEqual(fileName);
 
                     // cleanup


### PR DESCRIPTION
if the platform is windows phone, it will use a proper string to compare (//nativ) instead of the default 'file://' that it won't match with the platform.
This solves the problem for file.spec.114 and file.spec.115.
