### PR TITLE
CB-7242 Added wp8 subdirectory to localPlatforms variable

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -201,7 +201,7 @@ if (argv.plugman) {
         "android" : top_dir + "cordova-android" ,
         "ios" : top_dir + "cordova-ios" ,
         "blackberry10" : top_dir + "cordova-blackberry" ,
-        "wp8" : top_dir + "cordova-wp8" ,
+        "wp8" : top_dir + "cordova-wp8" + path.sep + "wp8",
         "windows8" : top_dir + "cordova-windows"
     };
 


### PR DESCRIPTION
createmobilespec --wp8 fails, because the path for wp8 on localPlatforms
is incomplete, it requires the wp8 subdirectory to work properly.
