### PR TITLE
[CB-7374] Use nodejs exec to run grunt in Windows

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -375,7 +375,8 @@ function updateJS() {
             }
 
             pushd(cordova_js_git_dir);
-            var code = shelljs.exec(path.join(__dirname, "node_modules", "grunt-cli", "bin", "grunt")).code;
+            var nodeCommand = /^win/.test(process.platform) ? process.argv[0] + " " : "";
+            var code = shelljs.exec(nodeCommand + path.join(__dirname, "node_modules", "grunt-cli", "bin", "grunt")).code;
             if (code) {
                 console.log("Failed to build js.");
                 process.exit(1);


### PR DESCRIPTION
Windows requires the specific path and file of the program to run the script, the nodejs binary file should be part of the command to run the grunt task over the cordova-js repository, in order to create the cordova.js files

If not, the execution stops.
