### PR TITLE
CB-7423 change failing whitelist test by adding a pattern it should matc...

### DIFF
--- a/www/autotest/tests/whitelist.tests.js
+++ b/www/autotest/tests/whitelist.tests.js
@@ -87,7 +87,7 @@ describe('Whitelist API (cordova.whitelist)', function () {
 
         itShouldMatch('file:///foo', ['file:///foo*']);
         itShouldMatch('file:///foo/bar.html', ['file:///foo*']);
-        itShouldMatch('file:///foo.html', [ ]);
+        itShouldMatch('file:///etc/foo.html', ['file:///*/foo.html']);
         itShouldNotMatch('http://www.apache.org/etc/foo', ['http://www.apache.org/foo*']);
         itShouldNotMatch('http://www.apache.org/foo', ['file:///foo*']);
 


### PR DESCRIPTION
...h
Previous test was assuming that the pattern "file:///*" was added to the whitelist in the Whitelist constructor. However, that was changed in Android and wasn't true for iOS. So the test would fail with no pattern added to the whitelist.
