### PR TITLE
CB-8295 Enable CSP for mobile spec

### DIFF
--- a/www/autotest/index.html
+++ b/www/autotest/index.html
@@ -25,6 +25,8 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
 
     <title>Cordova API Specs</title>
 

--- a/www/autotest/pages/all.html
+++ b/www/autotest/pages/all.html
@@ -23,6 +23,9 @@
 
 <html>
 <head>
+  <!-- Inject CSP -->
+  <script type="text/javascript" src="../../csp-incl.js"></script>
+
   <title>Cordova: API Specs</title>
 
   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />

--- a/www/autotest/pages/bridge.html
+++ b/www/autotest/pages/bridge.html
@@ -24,6 +24,9 @@
 <html>
 
 <head>
+  <!-- Inject CSP -->
+  <script type="text/javascript" src="../../csp-incl.js"></script>
+
   <title>Cordova: Device API Specs</title>
 
   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />

--- a/www/autotest/pages/datauri.html
+++ b/www/autotest/pages/datauri.html
@@ -22,6 +22,9 @@
 <html>
 
 <head>
+  <!-- Inject CSP -->
+  <script type="text/javascript" src="../../csp-incl.js"></script>
+
   <title>Cordova: Data URI tests</title>
 
   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />

--- a/www/autotest/pages/localXHR.html
+++ b/www/autotest/pages/localXHR.html
@@ -23,6 +23,9 @@
 
 <html>
 <head>
+  <!-- Inject CSP -->
+  <script type="text/javascript" src="../../csp-incl.js"></script>
+
   <title>Cordova: Local XHR Specs</title>
 
   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />

--- a/www/autotest/pages/platform.html
+++ b/www/autotest/pages/platform.html
@@ -24,6 +24,9 @@
 <html>
 
 <head>
+  <!-- Inject CSP -->
+  <script type="text/javascript" src="../../csp-incl.js"></script>
+
   <title>Cordova: Platform API Specs</title>
 
   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />

--- a/www/autotest/pages/storage.html
+++ b/www/autotest/pages/storage.html
@@ -24,6 +24,9 @@
 <html>
 
 <head>
+  <!-- Inject CSP -->
+  <script type="text/javascript" src="../../csp-incl.js"></script>
+
   <title>Cordova: Storage API Specs</title>
 
   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />
@@ -45,7 +48,7 @@
 
   <!-- Tests -->
   <script type="text/javascript" src="../tests/storage.tests.js"></script>
-  <script type="text/javascript" charset="utf-8" src="./run-tests.js"></script>      
+  <script type="text/javascript" charset="utf-8" src="./run-tests.js"></script>
 </head>
 
 <body>

--- a/www/autotest/pages/whitelist.html
+++ b/www/autotest/pages/whitelist.html
@@ -24,6 +24,9 @@
 <html>
 
 <head>
+  <!-- Inject CSP -->
+  <script type="text/javascript" src="../../csp-incl.js"></script>
+
   <title>Cordova: Whitelist API Specs</title>
 
   <meta name="viewport" content="width=device-width, height=device-height, user-scalable=yes, initial-scale=1.0" />

--- a/www/autotest/tests/bridge.tests.js
+++ b/www/autotest/tests/bridge.tests.js
@@ -24,22 +24,21 @@ describe('Bridge', function() {
     // Adding this spec is the way to show some useful information to user
     // and to avoid failure of test framework (see CB-7491)
     it("bridge spec will run on android only", function() {
-
         expect(cordova.platformId).toBe('android');
-
-        if (cordova.platformId == 'android') {
-            it("bridge.spec.1 should reject bridge from iframe with data: URL", function() {
-                var ifr = document.createElement('iframe');
-                var done = false;
-                ifr.src = 'data:text/html,';
-                ifr.onload = function() {
-                    var stolenSecret = ifr.contentWindow.prompt('', 'gap_init:');
-                    done = true;
-                    expect(!!stolenSecret).toBe(false);
-                };
-                document.body.appendChild(ifr);
-                waitsFor(function() { return done; });
-            });
-        }
     });
+
+    if (cordova.platformId == 'android') {
+        it("bridge.spec.1 should reject bridge from iframe with data: URL", function() {
+            var ifr = document.createElement('iframe');
+            var done = false;
+            ifr.src = 'data:text/html,';
+            ifr.onload = function() {
+                var stolenSecret = ifr.contentWindow.prompt('', 'gap_init:');
+                done = true;
+                expect(!!stolenSecret).toBe(false);
+            };
+            document.body.appendChild(ifr);
+            waitsFor(function() { return done; });
+        });
+    }
 });

--- a/www/battery/index.html
+++ b/www/battery/index.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,maximum-scale=1.0,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Cordova Mobile Spec</title>

--- a/www/benchmarks/index.html
+++ b/www/benchmarks/index.html
@@ -23,17 +23,21 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,maximum-scale=1.0,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Cordova Mobile Spec</title>
     <link rel="stylesheet" href="../master.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <script src="../cordova-incl.js"></script>
+    <script type="text/javascript" charset="utf-8" src="./index.js"></script>
   </head>
   <body id="stage" class="theme">
     <h1>Benchmarks</h1>
     <a href="autobench.html" class="btn large">AutoBench</a>
     <a href="arraybuffer.html" class="btn large">ArrayBuffer</a>
     <a href="exec.html" class="btn large">Exec Bridge</a>
-    <h2> </h2><div class="backBtn" onclick="backHome();">Back</div>
+    <h2> </h2><div class="backBtn">Back</div>
   </body>
 </html>      

--- a/www/benchmarks/index.js
+++ b/www/benchmarks/index.js
@@ -1,0 +1,4 @@
+window.onload = function() {
+  addListenerToClass('backBtn', backHome);
+}
+

--- a/www/csp-incl.js
+++ b/www/csp-incl.js
@@ -1,0 +1,63 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var PLAT;
+(function getPlatform() {
+    var platforms = {
+        amazon_fireos: /cordova-amazon-fireos/,
+        android: /Android/,
+        ios: /(iPad)|(iPhone)|(iPod)/,
+        blackberry10: /(BB10)/,
+        blackberry: /(PlayBook)|(BlackBerry)/,
+        // Since Windows Phone 8.1 uses completely different API more similar to Windows 8
+        // than to Windows phone 8 we need to detect it separately.
+        windowsphone81: /Windows Phone 8.1/,
+        windowsphone: /Windows Phone/,
+        windows8: /MSAppHost/,
+        firefoxos: /Firefox/
+    };
+    for (var key in platforms) {
+        if (platforms[key].exec(navigator.userAgent)) {
+            PLAT = key;
+            break;
+        }
+    }
+})();
+
+// To disable CSP, define _disableCSP and set to false, prior to the inclusion
+// of this file.
+if (!window._disableCSP) {
+    var cspMetaContent = null;
+    switch (PLAT) {
+        case 'android':
+        case 'ios':
+            cspMetaContent = 'default-src \'self\'; connect-src \'self\' http://cordova-filetransfer.jitsu.com;frame-src \'self\' data: gap:; img-src \'self\' data:; style-src \'self\' \'unsafe-inline\'';
+            break;
+    }
+
+    if (cspMetaContent) {
+        document.write('<meta http-equiv="Content-Security-Policy" content="' + cspMetaContent + '"/>');
+    }
+}
+else {
+  console.log('CSP injection is disabled.');
+}
+

--- a/www/disable-csp.js
+++ b/www/disable-csp.js
@@ -1,0 +1,1 @@
+_disableCSP = true;

--- a/www/events/index.html
+++ b/www/events/index.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,maximum-scale=1.0,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Cordova Mobile Spec</title>

--- a/www/index.html
+++ b/www/index.html
@@ -25,6 +25,9 @@
   <head>
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="csp-incl.js"></script>
+
     <title>Cordova Mobile Spec</title>
 	  <link rel="stylesheet" href="master.css" type="text/css" media="screen" title="no title" charset="utf-8">
 	  <script type="text/javascript" charset="utf-8" src="cordova-incl.js"></script>

--- a/www/keyboard/index.html
+++ b/www/keyboard/index.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,maximum-scale=1.0,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Cordova Mobile Spec</title>

--- a/www/lazyloadjs/index.html
+++ b/www/lazyloadjs/index.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Lazy-Loading of cordova-incl.js test</title>

--- a/www/misc/index.html
+++ b/www/misc/index.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,maximum-scale=1.0,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Cordova Mobile Spec</title>

--- a/www/sql/index.html
+++ b/www/sql/index.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,maximum-scale=1.0,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Cordova Mobile Spec</title>

--- a/www/storage/index.html
+++ b/www/storage/index.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <!-- Inject CSP -->
+    <script type="text/javascript" src="../csp-incl.js"></script>
+
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,maximum-scale=1.0,initial-scale=1.0" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <!-- ISO-8859-1 -->
     <title>Cordova Mobile Spec</title>


### PR DESCRIPTION
- Uses a javascript include file to document.write a CSP <meta> tag on page
- Minor changes to test pages where need to comply with CSP (e.g. remove inline event handler)
- Changed to Bridge auto tests to remove nested specs, which was causing an error on Android
- Some test pages excluded from CSP (e.g. those with heavy use of inline javascript)