### PR TITLE
Copy Mobilespec App Template Instead of Linking It

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -411,7 +411,7 @@ if (argv.plugman) {
     // Create the project using "cordova create"
     myDelete(cli_project_dir);
     console.log("Creating project mobilespec...");
-    shelljs.exec(cli + " create " + projectDirName + " org.apache.cordova.mobilespec MobileSpec_Tests --link-to cordova-mobile-spec/www");
+    shelljs.exec(cli + " create " + projectDirName + " org.apache.cordova.mobilespec MobileSpec_Tests --copy-from cordova-mobile-spec/www");
     shelljs.cp("-f", path.join(mobile_spec_git_dir, 'config.xml'), path.join(projectDirName, 'config.xml'));
 
     // Config.json file ---> linked to local libraries
@@ -506,7 +506,7 @@ function installPlugins() {
         } else {
             shelljs.exec(cli + " plugin add " + path.join(mobile_spec_git_dir, "dependencies-plugin") + searchpath + linkPluginsFlag + browserifyFlag);
         }
-        
+
         if (argv.thirdpartyplugins || argv.cprplugins) {
             var mapVars = ' --variable API_KEY_FOR_ANDROID="AIzaSyBICVSs9JqT7WdASuN5HSe7w-pCE0n_X88" --variable API_KEY_FOR_IOS="AIzaSyAikyYG24YYFvq5Vy41P5kppsfO2GgF9jM"';
             var fbVars = ' --variable APP_ID=value --variable APP_NAME=value';

--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -121,6 +121,7 @@ var top_dir =             process.cwd() + path.sep,
                                                  "\t\t\tUse only when you know what you are doing, this should be very rare.")
                    .boolean("linkplugins").describe("linkplugins", "Use the --link flag when running `cordova plugin add`.\n")
                    .boolean("linkplatforms").describe("linkplatforms", "Use the --link flag when running `cordova platform add`.\n")
+                   .boolean("copywww").describe("copywww", "Use --copy-from instead of --link-to when running `cordova create`.\n")
                    .boolean("link").describe("link", "Alias for --linkplugins --linkplatforms.\n")
                    .boolean("browserify").describe("browserify", "Use the --browserify flag when running `cordova plugin add`.\n")
                    .boolean("telerikplugins").describe("telerikplugins", "Adds a bunch of known-to-be-popular plugins from Telerik-Verified-Plugins.\n")
@@ -411,7 +412,8 @@ if (argv.plugman) {
     // Create the project using "cordova create"
     myDelete(cli_project_dir);
     console.log("Creating project mobilespec...");
-    shelljs.exec(cli + " create " + projectDirName + " org.apache.cordova.mobilespec MobileSpec_Tests --copy-from cordova-mobile-spec/www");
+    var copyOrLinkFlag = argv.copywww ? '--copy-from' : '--link-to';
+    shelljs.exec(cli + " create " + projectDirName + " org.apache.cordova.mobilespec MobileSpec_Tests " + copyOrLinkFlag + " cordova-mobile-spec/www");
     shelljs.cp("-f", path.join(mobile_spec_git_dir, 'config.xml'), path.join(projectDirName, 'config.xml'));
 
     // Config.json file ---> linked to local libraries


### PR DESCRIPTION
Instead of symlinking the mobilespec app template when calling `createmobilespec`, copy the template's contents instead. Justifications for this are:
- if files are changed in the created `mobilespec` app, they should not change the template
- symlinking doesn't offer an advantage during development since re-running `createmobilespec` is required anyway when plugins are changed
- on windows symlinks require Administrator privileges