### PR TITLE
CB-8727 Fix failing WebSQL test on Android 5.1

### DIFF
--- a/www/sql/index.js
+++ b/www/sql/index.js
@@ -98,7 +98,6 @@ function increaseQuota(index) {
 var databaseOutput = function(s) {
     var el = document.getElementById("database_results");
     el.innerHTML = el.innerHTML + s + "<br>";
-    el.scrollByLines(20000);
 };
 
 /**


### PR DESCRIPTION
- scrollByLines is an unknown function in Android 5.1
- removed because it causes the exception and does not affect the test itself