### PR TITLE
CB-9774 File Transfer download cdvfile fails

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -47,7 +47,8 @@
     <allow-navigation href="https://www.google.co.uk" />
     <allow-navigation href="http://techslides.com" />
     <allow-navigation href="httpssss://example.com" />
-    
+    <allow-navigation href="cdvfile:*" />
+
     <allow-intent href="sms:*" />
     <allow-intent href="mailto:*" />
     <allow-intent href="tel:*" />

--- a/www/csp-incl.js
+++ b/www/csp-incl.js
@@ -54,7 +54,7 @@ if (!window._disableCSP) {
                             ' connect-src \'self\' http://cordova-filetransfer.jitsu.com;' +
                             ' media-src \'self\' http://cordova.apache.org/downloads/;' +
                             ' frame-src \'self\' http://stealbridgesecret.test/ data: gap:;' +
-                            ' img-src \'self\' data:;' +
+                            ' img-src \'self\' data: cdvfile:;' +
                             ' style-src \'self\' \'unsafe-inline\'';
             break;
     }


### PR DESCRIPTION
[Jira issue](https://issues.apache.org/jira/browse/CB-9774)

`<allow-navigation href="cdvfile:*" />` is needed for Android only.
Playing video via `cdvfile` in video tag `src` is not supported.