### PR TITLE
CB-10595: Windows Store 8.1 builds finish with warning 'Expected undefined to be defined' on running mobilespec storage tests

### DIFF
--- a/cordova-plugin-mobilespec-tests/tests/storage.tests.js
+++ b/cordova-plugin-mobilespec-tests/tests/storage.tests.js
@@ -179,6 +179,10 @@ exports.defineAutoTests = function () {
 
         describe("HTML 5 Storage", function () {
             it("storage.spec.9 should exist", function () {
+                //IE doesn't support openDatabase method
+                if (isWindows || isWindowsPhone) {
+                    pending();
+                }
                 expect(window.openDatabase).toBeDefined();
             });
 
@@ -214,7 +218,7 @@ exports.defineAutoTests = function () {
                     if (!window.openDatabase) {
                         pending();
                     }
-                   
+
                     if (isIOSWKWebView) {
                         pending();
                     }


### PR DESCRIPTION
IE does not support openDatabase method. So, marking the test as pending. (similar to storage.spec.17 test - the next test after the failing test)

@dblotsky @riknoll @rakatyal @nikhilkh Can you please review and merge this PR?
