### PR TITLE
CB-12067: Added cordova-plugin-compat to default plugins

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -204,6 +204,7 @@ var PLUGREG_PLUGINS = [
 
 var DEFAULT_PLUGINS = [
     'cordova-plugin-battery-status',
+    'cordova-plugin-compat',
     'cordova-plugin-camera',
     'cordova-plugin-console',
     'cordova-plugin-contacts',


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Fixes mobilespec so that we can do dev on cordova-plugin-compat and plugins that need to use it AT THE SAME TIME

### What testing has been done on this change?
I ran mobilespec and it worked.

### Checklist
- [ x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ x] Added automated test coverage as appropriate for this change.

