### PR TITLE
Tip to delete existing mobilespec if it exists

### DIFF
--- a/createmobilespec/README.md
+++ b/createmobilespec/README.md
@@ -78,6 +78,9 @@ If anything is going wrong and the existing output does not help, add the `--deb
 
 ### Create the App
 
+Caution: If the generated `mobilespec` project already exists, it is recommended
+to delete the project before proceeding.
+
 To for example create the app for the Android platform, run:
 
     (node) cordova-mobile-spec/createmobilespec/createmobilespec.js --android


### PR DESCRIPTION
before running `createmobilespec.js`

(this seems to help me avoid the quirks I documented before)

Note that this proposal is expected to conflict with PR #154, which I did not get a chance to review yet. I am proposing this tip anyway due to its importance IMHO, to capture the info and avoid losing track of it. I hope to review the documentation updates proposed in PR #154 within the next few days.