### PR TITLE
Remove deprecated cordova-plugin-compat

### DIFF
--- a/createmobilespec/createmobilespec.js
+++ b/createmobilespec/createmobilespec.js
@@ -145,7 +145,6 @@ var top_dir =             process.cwd() + path.sep,
 
 var DEFAULT_PLUGINS = [
     'cordova-plugin-battery-status',
-    'cordova-plugin-compat',
     'cordova-plugin-camera',
     'cordova-plugin-console',
     'cordova-plugin-contacts',


### PR DESCRIPTION
as discussed in PR #181:
> `cordova-plugin-compat` is deprecated because it was integrated into cordova-android 6.3.0

> It is no longer possible to test with older versions of cordova-android due to the updated key & gradle location in c03b7c1 (PR #152).