### PR TITLE
fix preparation commands in README.md

### DIFF
--- a/createmobilespec/README.md
+++ b/createmobilespec/README.md
@@ -46,8 +46,8 @@ and a way to use the platform-centered workflow instead of the CLI.
     # Create a new folder, e.g. `cordova` and `cd cordova` into it.
     git clone https://github.com/apache/cordova-coho.git
     cd cordova-coho && npm install && cd ..
-    node cordova-coho/coho repo-clone -r mobile-spec -r tools -r plugins -r active-platforms
-    node cordova-coho/coho npm-link
+    node ./cordova-coho/coho repo-clone -r mobile-spec -r tools -r plugins -r active-platforms
+    node ./cordova-coho/coho npm-link
     ```
 
     After this you should have 30+ folders in your `cordova` folder.

--- a/createmobilespec/README.md
+++ b/createmobilespec/README.md
@@ -44,7 +44,7 @@ and a way to use the platform-centered workflow instead of the CLI.
 
     ```shell
     # Create a new folder, e.g. `cordova` and `cd cordova` into it.
-    git clone https://github.com/apache/cordova-coho.git
+    git clone https://github.com/apache/cordova-coho
     cd cordova-coho && npm install && cd ..
     node ./cordova-coho/coho repo-clone -r mobile-spec -r tools -r plugins -r active-platforms
     node ./cordova-coho/coho npm-link

--- a/createmobilespec/README.md
+++ b/createmobilespec/README.md
@@ -45,7 +45,7 @@ and a way to use the platform-centered workflow instead of the CLI.
     ```shell
     # Create a new folder, e.g. `cordova` and `cd cordova` into it.
     git clone https://github.com/apache/cordova-coho.git
-    cd cordova-coho & npm install & cd ..
+    cd cordova-coho && npm install && cd ..
     node cordova-coho/coho repo-clone -r mobile-spec -r tools -r plugins -r active-platforms
     node cordova-coho/coho npm-link
     ```
@@ -54,7 +54,7 @@ and a way to use the platform-centered workflow instead of the CLI.
 
 2. As `cordova-mobile-spec` has a special structure, you have to install dependencies in `createmobilespec` manually:
     ```shell
-    cd cordova-mobile-spec/createmobilespec & npm install & cd ../..
+    cd cordova-mobile-spec/createmobilespec && npm install && cd ../..
     ```
 3. You are now ready to use `createmobilespec.js` with the commands below.
 


### PR DESCRIPTION
__updated June 2020:__

replace `&` with `&&`

## Testing

- [x] tested these updated commands on my macOS Catalina system
- [ ] I would like to check that I can continue getting mobilespec project to work _on Windows_ (I recall having some troubles with cordova-windows)