### PR TITLE
doc: fix shell commands in document

### DIFF
--- a/createmobilespec/README.md
+++ b/createmobilespec/README.md
@@ -45,7 +45,7 @@ and a way to use the platform-centered workflow instead of the CLI.
     ```shell
     # Create a new folder, e.g. `cordova` and `cd cordova` into it.
     git clone https://github.com/apache/cordova-coho.git
-    cd cordova-coho & npm install & cd ..
+    cd cordova-coho && npm install && cd ..
     node cordova-coho/coho repo-clone -r mobile-spec -r tools -r plugins -r active-platforms
     node cordova-coho/coho npm-link
     ```
@@ -54,7 +54,7 @@ and a way to use the platform-centered workflow instead of the CLI.
 
 2. As `cordova-mobile-spec` has a special structure, you have to install dependencies in `createmobilespec` manually:
     ```shell
-    cd cordova-mobile-spec/createmobilespec & npm install & cd ../..
+    cd cordova-mobile-spec/createmobilespec && npm install && cd ../..
     ```
 3. You are now ready to use `createmobilespec.js` with the commands below.
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

all

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I would like to copy-paste documented shell commands.

### Description
<!-- Describe your changes in detail -->

See commit(s):

- use double-ampersand (`&&`) in shell commands, as needed to work in `*nix` shells

### Testing
<!-- Please describe in detail how you tested your changes. -->

- [x] tested the affected steps on my macOS Catalina (Unix) machine
- [ ] test on Windows commander (cmd) shell & PowerShell

### Checklist

- ~~I've run the tests to see all new and existing tests pass~~
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- [x] I've updated the documentation if necessary