### PR TITLE
fix: make sure cordova-plugin-test-framework node modules are installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,11 @@ async function runCmdSequentially (commands, options) {
             packagesToInstall.push(`cordova plugin add ${platformTestDir}`);
         }
     }
+
+    // Make sure to npm install "cordova-plugin-test-framework"
+    print.process(`Installing npm packages for cordova-plugin-test-framework.`);
+    await runCmd('npm install', { cwd: testFrameworkPluginDir });
+
     // Adding internal plugins
     for (const p of INTERNAL_PLUGINS) {
         packagesToInstall.push(`cordova plugin add ${p}`);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Make sure `cordova-plugin-test-framework` node modules are installed.

### Description
<!-- Describe your changes in detail -->

If user forget to install node modules for the `cordova-plugin-test-framework` repo, mobilespec will crash.

Added a step to run `npm install` in the `cordova-plugin-test-framework` directory.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested by running the mobile-spec tool

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
