### PR TITLE
fix: build android only when cordova-android is added

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,12 +261,14 @@ async function runCmdSequentially (commands, options) {
     await runCmdSequentially(packagesToInstall, { cwd: projectDir });
 
     // Build Cordova-Android once to ensure gradle wrapper is created
-    try {
-        const buildAndroid = 'cordova build android';
-        print.process(buildAndroid);
-        await runCmd(buildAndroid, { cwd: projectDir });
-    } catch (error) {
-        print.error('An error occurred while building the Android project.', error);
+    if (platforms.includes('cordova-android')) {
+        try {
+            const buildAndroid = 'cordova build android';
+            print.process(buildAndroid);
+            await runCmd(buildAndroid, { cwd: projectDir });
+        } catch (error) {
+            print.error('An error occurred while building the Android project.', error);
+        }
     }
 
     print.success('Successfully created and mobile spec project.');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Do no run android build when the cordova-android platform is not installed.

### Description
<!-- Describe your changes in detail -->

Added a conditional check to ensure that android platform was selected to be added before running android build.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested by running mobilespec

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
